### PR TITLE
lowercase sha

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function createHmacSigner(bits) {
     if (!bufferOrString(secret))
       throw typeError(MSG_INVALID_SECRET);
     thing = normalizeInput(thing);
-    const hmac = crypto.createHmac('SHA' + bits, secret);
+    const hmac = crypto.createHmac('sha' + bits, secret);
     const sig = (hmac.update(thing), hmac.digest('base64'))
     return base64url.fromBase64(sig);
   }


### PR DESCRIPTION
I got error `SHA256 is not supported (we accept pull requests)` when verifying jwt. Dig the code and notice that crypto package has this exports `exports.sha256 = require('./sha256')(Buffer, Hash)` 

This PR just lowercases the first argument to `'sha' + bits` for `createHmac` method in `createHmacSigner` function.