### PR TITLE
fix(ecdsa) translate between DER encoded and JOSE-style signatures. fixes #3

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "dependencies": {
     "base64url": "~0.0.4",
-    "buffer-equal-constant-time": "^1.0.1"
+    "buffer-equal-constant-time": "^1.0.1",
+    "ecdsa-sig-formatter": "^1.0.0"
   },
   "devDependencies": {
     "tap": "~0.3.3"


### PR DESCRIPTION
OpenSSL (and thus node) encode the r/s parameters of an ECDSA signature as an ASN.1 ESCDSA-Sig-Value object
JOSE/JWA/RFC7518 require the parameters simply be concatenated