### PR TITLE
DeprecationWarning: Using Buffer without `new` will soon stop working

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ function createHmacSigner(bits) {
 function createHmacVerifier(bits) {
   return function verify(thing, signature, secret) {
     var computedSig = createHmacSigner(bits)(thing, secret);
-    return bufferEqual(Buffer(signature), Buffer(computedSig));
+    return bufferEqual(new Buffer(signature), new Buffer(computedSig));
   }
 }
 


### PR DESCRIPTION
DeprecationWarning: Using Buffer without `new` will soon stop working. Use `new Buffer()`, or preferably `Buffer.from()`, `Buffer.allocUnsafe()` or `Buffer.alloc()` instead.
