### PR TITLE
use Buffer.from() and Buffer.alloc() (DeprecationWarning in node 7.0.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ node_js:
   - 4
   - 5
   - 6
+  - 7
 notifications:
   email:
     recipients:

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var bufferEqual = require('buffer-equal-constant-time');
 var base64url = require('base64url');
+var Buffer = require('safe-buffer').Buffer;
 var crypto = require('crypto');
 var formatEcdsa = require('ecdsa-sig-formatter');
 var util = require('util');
@@ -39,7 +40,7 @@ function createHmacSigner(bits) {
 function createHmacVerifier(bits) {
   return function verify(thing, signature, secret) {
     var computedSig = createHmacSigner(bits)(thing, secret);
-    return bufferEqual(Buffer(signature), Buffer(computedSig));
+    return bufferEqual(Buffer.from(signature), Buffer.from(computedSig));
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "dependencies": {
     "base64url": "2.0.0",
     "buffer-equal-constant-time": "1.0.1",
-    "ecdsa-sig-formatter": "1.0.7"
+    "ecdsa-sig-formatter": "1.0.7",
+    "safe-buffer": "^5.0.1"
   },
   "devDependencies": {
     "semver": "4.3.6",

--- a/test/jwa.test.js
+++ b/test/jwa.test.js
@@ -2,6 +2,7 @@ const path = require('path');
 const base64url = require('base64url');
 const formatEcdsa = require('ecdsa-sig-formatter');
 const spawn = require('child_process').spawn;
+const Buffer = require('safe-buffer').Buffer;
 const semver = require('semver');
 const fs = require('fs');
 const test = require('tap').test;
@@ -77,7 +78,7 @@ BIT_DEPTHS.forEach(function (bits) {
     const input = 'iodine';
     const algo = jwa('rs'+bits);
     const dgst = spawn('openssl', ['dgst', '-sha'+bits, '-sign', __dirname + '/rsa-private.pem']);
-    var buffer = Buffer(0);
+    var buffer = Buffer.alloc(0);
 
     dgst.stdout.on('data', function (buf) {
       buffer = Buffer.concat([buffer, buf]);
@@ -115,7 +116,7 @@ BIT_DEPTHS.forEach(function (bits) {
     const input = 'strawberry';
     const algo = jwa('es'+bits);
     const dgst = spawn('openssl', ['dgst', '-sha'+bits, '-sign', __dirname + '/ec'+bits+'-private.pem']);
-    var buffer = Buffer(0);
+    var buffer = Buffer.alloc(0);
     dgst.stdin.end(input);
     dgst.stdout.on('data', function (buf) {
       buffer = Buffer.concat([buffer, buf]);


### PR DESCRIPTION
Gets rid of the following:

```
DeprecationWarning: Using Buffer without `new` will soon stop working.
Use `new Buffer()`, or preferably `Buffer.from()`, `Buffer.allocUnsafe()` or 
`Buffer.alloc()` instead.
```
