### PR TITLE
Switch to maintained b64u package

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var bufferEqual = require('buffer-equal-constant-time');
-var base64url = require('base64url');
+var base64url = require('b64u');
 var Buffer = require('safe-buffer').Buffer;
 var crypto = require('crypto');
 var formatEcdsa = require('ecdsa-sig-formatter');

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "dependencies": {
-    "base64url": "2.0.0",
+    "b64u": "2.0.0",
     "buffer-equal-constant-time": "1.0.1",
     "ecdsa-sig-formatter": "1.0.9",
     "safe-buffer": "^5.0.1"

--- a/test/jwa.test.js
+++ b/test/jwa.test.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const base64url = require('base64url');
+const base64url = require('b64u');
 const formatEcdsa = require('ecdsa-sig-formatter');
 const spawn = require('child_process').spawn;
 const Buffer = require('safe-buffer').Buffer;


### PR DESCRIPTION
The `base64url` package has not been updated since 2016 and currently has [a critical issue](https://github.com/brianloveswords/base64url/issues/13) that prevents TypeScript users from using it with any version of Node other than v6.0.0.  This affects both the `base64url` package and all packages that depend on it, including this one.

This PR updates replaces `base64url` with `b64u`, a maintained, API-identical equivalent package.  Since the API is identical, this should require no additional changes.