### PR TITLE
PS*: fix PS* signatures

### DIFF
--- a/index.js
+++ b/index.js
@@ -170,7 +170,11 @@ function createPSSKeySigner(bits) {
     checkIsPrivateKey(privateKey);
     thing = normalizeInput(thing);
     var signer = crypto.createSign('RSA-SHA' + bits);
-    var sig = (signer.update(thing), signer.sign({key: privateKey, padding: crypto.constants.RSA_PKCS1_PSS_PADDING}, 'base64'));
+    var sig = (signer.update(thing), signer.sign({
+      key: privateKey,
+      padding: crypto.constants.RSA_PKCS1_PSS_PADDING,
+      saltLength: crypto.constants.RSA_PSS_SALTLEN_DIGEST
+    }, 'base64'));
     return fromBase64(sig);
   }
 }
@@ -182,7 +186,11 @@ function createPSSKeyVerifier(bits) {
     signature = toBase64(signature);
     var verifier = crypto.createVerify('RSA-SHA' + bits);
     verifier.update(thing);
-    return verifier.verify({key: publicKey, padding: crypto.constants.RSA_PKCS1_PSS_PADDING}, signature, 'base64');
+    return verifier.verify({
+      key: publicKey,
+      padding: crypto.constants.RSA_PKCS1_PSS_PADDING,
+      saltLength: crypto.constants.RSA_PSS_SALTLEN_DIGEST
+    }, signature, 'base64');
   }
 }
 

--- a/test/jwa.test.js
+++ b/test/jwa.test.js
@@ -174,7 +174,7 @@ if (semver.satisfies(nodeVersion, '^6.12.0 || >=8.0.0')) {
     test('PS'+bits+': openssl sign -> js verify', function (t) {
       const input = 'iodine';
       const algo = jwa('ps'+bits);
-      const dgst = spawn('openssl', ['dgst', '-sha'+bits, '-sigopt', 'rsa_padding_mode:pss', '-sign', __dirname + '/rsa-private.pem']);
+      const dgst = spawn('openssl', ['dgst', '-sha'+bits, '-sigopt', 'rsa_padding_mode:pss', '-sigopt', 'rsa_pss_saltlen:-1', '-sign', __dirname + '/rsa-private.pem']);
       var buffer = Buffer.alloc(0);
 
       dgst.stdout.on('data', function (buf) {


### PR DESCRIPTION
https://tools.ietf.org/html/rfc7518#section-3.5 describes "The size of the salt value is the same size as
   the hash function output.".

Fixes: https://github.com/brianloveswords/node-jws/issues/85
PR-URL: https://github.com/brianloveswords/node-jwa/pull/34