### PR TITLE
fix: remove safe-buffer dependency, use built-in Buffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-var Buffer = require('safe-buffer').Buffer;
 var crypto = require('crypto');
 var formatEcdsa = require('ecdsa-sig-formatter');
 var util = require('util');

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
   },
   "dependencies": {
     "buffer-equal-constant-time": "^1.0.1",
-    "ecdsa-sig-formatter": "1.0.11",
-    "safe-buffer": "^5.0.1"
+    "ecdsa-sig-formatter": "1.0.11"
   },
   "devDependencies": {
     "base64url": "^2.0.0",

--- a/test/A.1/test.js
+++ b/test/A.1/test.js
@@ -5,7 +5,6 @@
 const fs = require('fs');
 const path = require('path');
 
-const Buffer = require('safe-buffer').Buffer;
 const test = require('tap').test;
 
 const jwa = require('../../');

--- a/test/A.2/test.js
+++ b/test/A.2/test.js
@@ -5,7 +5,6 @@
 const fs = require('fs');
 const path = require('path');
 
-const Buffer = require('safe-buffer').Buffer;
 const jwkToPem = require('jwk-to-pem');
 const test = require('tap').test;
 

--- a/test/A.3/test.js
+++ b/test/A.3/test.js
@@ -5,7 +5,6 @@
 const fs = require('fs');
 const path = require('path');
 
-const Buffer = require('safe-buffer').Buffer;
 const jwkToPem = require('jwk-to-pem');
 const test = require('tap').test;
 

--- a/test/A.4/test.js
+++ b/test/A.4/test.js
@@ -5,7 +5,6 @@
 const fs = require('fs');
 const path = require('path');
 
-const Buffer = require('safe-buffer').Buffer;
 const jwkToPem = require('jwk-to-pem');
 const test = require('tap').test;
 

--- a/test/jwa.test.js
+++ b/test/jwa.test.js
@@ -3,7 +3,6 @@ const path = require('path');
 const base64url = require('base64url');
 const formatEcdsa = require('ecdsa-sig-formatter');
 const spawn = require('child_process').spawn;
-const Buffer = require('safe-buffer').Buffer;
 const semver = require('semver');
 const fs = require('fs');
 const test = require('tap').test;


### PR DESCRIPTION
## Summary
- Removed `safe-buffer` dependency from `package.json`
- Replaced `require('safe-buffer').Buffer` with the built-in `Buffer` global in `index.js` and all test files
- `Buffer.from()` and `Buffer.alloc()` are available natively in all supported Node.js versions (>=6), making `safe-buffer` unnecessary
- This also fixes ESM bundling issues where `safe-buffer`'s internal `require("buffer")` causes runtime errors

All tests pass.

Closes #55