### PR TITLE
ci: skip verifyRelease in prepare-release dry-run and add changelog

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -38,7 +38,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Run semantic-release with dry-run to detect version
-          NEXT_VERSION=$(npx semantic-release --dry-run --verify-conditions false | tee /dev/stderr | awk '/The next release version is/{print $NF}')
+          set -o pipefail
+          if ! OUTPUT=$(npx semantic-release --dry-run --verify-conditions false --verify-release false 2>&1); then
+            echo "$OUTPUT"
+            echo "::error::semantic-release failed during version detection"
+            exit 1
+          fi
+          echo "$OUTPUT"
+          NEXT_VERSION=$(echo "$OUTPUT" | awk '/The next release version is/{print $NF}')
           echo "next=$NEXT_VERSION" >> $GITHUB_OUTPUT
 
       - name: Update package.json
@@ -46,6 +53,10 @@ jobs:
         run: npm version "$NEXT_VERSION" --no-git-tag-version
         env:
           NEXT_VERSION: ${{ steps.version.outputs.next }}
+
+      - name: Update CHANGELOG.md
+        if: steps.version.outputs.next != ''
+        run: npm run update-changelog
 
       - name: Create Pull Request
         if: steps.version.outputs.next != ''
@@ -61,6 +72,7 @@ jobs:
 
             **Changes:**
             - Updated version in `package.json` to ${{ steps.version.outputs.next }}
+            - Updated `CHANGELOG.md` with release notes
 
             **Next Steps:**
             Review and merge this PR to trigger the publish workflow.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@commitlint/cli": "^20.3.1",
     "@commitlint/config-conventional": "^20.3.1",
     "@semantic-release/exec": "^7.0.3",
+    "conventional-changelog": "^7.2.1",
     "conventional-changelog-conventionalcommits": "^9.3.0",
     "base64url": "^2.0.0",
     "husky": "^9.1.7",
@@ -30,7 +31,8 @@
   },
   "scripts": {
     "prepare": "husky",
-    "test": "make test"
+    "test": "make test",
+    "update-changelog": "conventional-changelog -p conventionalcommits -i CHANGELOG.md"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Fixes the `Prepare Release` workflow, two bugs introduced by https://github.com/auth0/node-jwa/pull/60

The `Detect Next Version` step ran `semantic-release --dry-run --verify-conditions false`. That flag only skips the `verifyConditions` step. The `verifyRelease` step still executed the `@semantic-release/exec` plugin's `verifyReleaseCmd`, which runs `npm pack` and then `rl-wrapper`. As a result:

- **`rl-wrapper: not found`** : that binary is only installed in`release.yml`, not `prepare-release.yml`, so the step fails.
- **A stray `.tgz` in the release PR** : `npm pack` leaves `*.tgz` in the workspace, which `create-pull-request` then commits into the release PR.

This PR fixes both issues by adding `--verify-release false` so the dry-run only runs `analyzeCommits` (still using the `conventionalcommits` preset from `.releaserc.json`), and never triggers `npm pack` / `rl-wrapper`.

This PR also adds a `CHANGELOG.md` generation step and hardens `Detect Next Version` to fail the step on a non-zero `semantic-release` exit instead of masking it behind the `awk` pipe.

### Testing

Ran the dry-run command locally and verified that:

- Version detection works: `The next release version is x.y.z` is printed and captured by the `awk` pipeline.
- No `.tgz` is created.
- No `rl-wrapper` invocation.
- `CHANGELOG.md` is updated with a new conventionalcommits-formatted section.